### PR TITLE
updated readme to use `main` as default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ However, migrating existing (large) Xcode project to Bazel is not easy. It requi
 ## Usage
 
 ```swift
-mint install XcodeMigrate/XcodeMigrate
+mint install XcodeMigrate/XcodeMigrate@main
 mint run xcode-migrate generate -p /path/to/your.xcodeproj
 ```
 


### PR DESCRIPTION
The actual default fails to install as per the current `README.md` this is needed until `mint` team support `main` as alternative to `master` 

Refer: 

https://github.com/XcodeMigrate/XcodeMigrate/issues/29 
https://github.com/yonaskolb/Mint/pull/204